### PR TITLE
Support bash globs when shell is bash (default) #69 : in macos sh is …

### DIFF
--- a/makesure_candidate
+++ b/makesure_candidate
@@ -179,11 +179,11 @@ function calcGlob(goalName, pattern,   script, file) {
   GlobCnt = 0
   GlobGoalName = goalName
   split("",GlobFiles)
-  gsub(/ /,"\\ ",pattern)
-  script = MyDirScript ";for f in ./" pattern ";do test -e \"$f\" && echo \"$f\";done"
+  script = MyDirScript ";for f in " pattern ";do test -e \"$f\" && echo \"$f\";done"
+  if ("sh" != Shell)
+    script = Shell " -c " quoteArg(script)
   while ((script | getline file)>0) {
     GlobCnt++
-    file = substr(file, 3)
     arrPush(GlobFiles,file)
   }
   close(script)
@@ -559,7 +559,7 @@ function quicksort(data, left, right,   i, last) {
   quicksortSwap(data, left, int((left + right) / 2))
   last = left
   for (i = left + 1; i <= right; i++)
-    if (natOrder(data[i], data[left],1,1) < 1)
+    if (natOrder(data[i], data[left],1,1) < 0)
       quicksortSwap(data, ++last, i)
   quicksortSwap(data, left, last)
   quicksort(data, left, last - 1)


### PR DESCRIPTION
…bash so this test fails there