### PR TITLE
Simplify selfUpdate()

### DIFF
--- a/tests/200_update.tush
+++ b/tests/200_update.tush
@@ -5,7 +5,7 @@ $ { ./$MAKESURE -f tests/200_update.sh test_err; echo 'exit_code '$?; } | awk '/
 | VER
 | selfupdate 1
 |   goal 'test_err' failed
-@ wget/curl not found
+@ failed to retrieve the latest version: wget/curl not found
 @ Please use manual update: https://makesure.dev/Installation.html
 ? 1
 


### PR DESCRIPTION
First of all - I'm not an AWK expert, so if you disagree with the approach I'm totally fine with you taking the general idea, closing this PR and implementing it how you see fit. Or just closing :)

Also, I didn't update the shell wrappers around `makesure.awk`, as I'm not sure what is the process there. I used `makesure candidate` for running tests, but didn't include the updated `makesure_candidate` file in the commit.

---

This PR simplifies the selfUpdate() function by utilizing the https://api.github.com/repos/xonixx/makesure/releases/latest API call. The main benefit is avoiding having to guess the latest version, but not running downloaded binaries automatically is a nice bonus for those of us who'd like to inspect the updated `makesure` before running it.

The other simplification here is relying on wget or curl for hanldling HTTP errors instead of parsing them manually from the response. This was done by using the `--fail-with-body` curl option, and removing the `if` clause for wget that was ignoring the response code 8.

One test case was fixed to reflect new (somewhat more verbose) error output.